### PR TITLE
Update fluentd-forwarder-build-config-template.yaml

### DIFF
--- a/fluentd-forwarder-build-config-template.yaml
+++ b/fluentd-forwarder-build-config-template.yaml
@@ -56,7 +56,7 @@ objects:
 parameters:
   - name: GIT_URI
     description: The Git URI.
-    value: "https://github.com/CDCgov/openshift-fluentd-forwarder.git"
+    value: "https://github.com/childofthewired/openshift-fluentd-forwarder.git"
     required: true
   - name: GIT_REF
     description: The git reference (tag, branch or other reference) to build from.


### PR DESCRIPTION
Updates the git uri in the build template to ensure that it pulls from this git repo, and reflects the restrictions that were made to the upstream common-installer.sh